### PR TITLE
Fix errors and leaks

### DIFF
--- a/src/whep-client.c
+++ b/src/whep-client.c
@@ -249,6 +249,8 @@ int main(int argc, char *argv[]) {
 	}
 	g_free(auto_turn_server);
 
+	gst_deinit();
+
 	WHEP_LOG(LOG_INFO, "\nBye!\n");
 	exit(0);
 }
@@ -364,11 +366,10 @@ static gboolean whep_initialize(void) {
 	guint rtp_latency = 0;
 	g_object_get(rtpbin, "latency", &rtp_latency, NULL);
 	WHEP_PREFIX(LOG_INFO, "Configured jitter-buffer size (latency) for PeerConnection to %ums\n", rtp_latency);
+	gst_object_unref(rtpbin);
 
 	/* Start the pipeline */
 	gst_element_set_state(pipeline, GST_STATE_READY);
-	/* Lifetime is the same as the pipeline itself */
-	gst_object_unref(pc);
 
 	WHEP_PREFIX(LOG_INFO, "Starting the GStreamer pipeline\n");
 	GstStateChangeReturn ret = gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_PLAYING);
@@ -576,6 +577,7 @@ static void whep_answer_available(GstPromise *promise, gpointer user_data) {
 	/* Now that a DTLS stack is available, try monitoring the DTLS state too */
 	GstElement *dtls = gst_bin_get_by_name(GST_BIN(pc), "dtlsdec0");
 	g_signal_connect(dtls, "notify::connection-state", G_CALLBACK(whep_dtls_connection_state), NULL);
+	gst_object_unref(dtls);
 
 	/* Now that the answer is ready, send it to the WHEP resource via PATCH
 	 * (unless we're not tricking, in which case we wait for gathering to be


### PR DESCRIPTION
When stopping using Ctrl-c, the following error was seen

(whep-client:78824): GStreamer-CRITICAL **: 13:30:41.572: Trying to dispose object "webrtcbin0", but it still has a parent "pipeline0". You need to let the parent manage the object instead of unreffing the object directly.

Also fix leaks due to missing unrefs.

gst_deinit is required to debug leaks.

GST_TRACERS="leaks" GST_DEBUG="GST_TRACER:7,leaks:6" ./whep-client -u http://localhost:7090/whep/endpoint/abc123 -n -f